### PR TITLE
[DAT 1971] upgrade cuda driver to 11.4.2

### DIFF
--- a/11/jdk/ubuntu/Dockerfile.hotspot.releases.slim
+++ b/11/jdk/ubuntu/Dockerfile.hotspot.releases.slim
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM nvidia/cuda:11.1-cudnn8-runtime-ubuntu18.04
+FROM nvidia/cuda:11.0.3-cudnn8-runtime-ubuntu20.04
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/11/jdk/ubuntu/Dockerfile.hotspot.releases.slim
+++ b/11/jdk/ubuntu/Dockerfile.hotspot.releases.slim
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM nvidia/cuda:11.0.3-cudnn8-runtime-ubuntu20.04
+FROM nvidia/cuda:11.2.2-cudnn8-runtime-ubuntu20.04
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/11/jdk/ubuntu/Dockerfile.hotspot.releases.slim
+++ b/11/jdk/ubuntu/Dockerfile.hotspot.releases.slim
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM nvidia/cuda:11.5.0-cudnn8-runtime-ubuntu20.04
+FROM nvidia/cuda:11.4.2-cudnn8-runtime-ubuntu20.04
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/11/jdk/ubuntu/Dockerfile.hotspot.releases.slim
+++ b/11/jdk/ubuntu/Dockerfile.hotspot.releases.slim
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM nvidia/cuda:11.2.2-cudnn8-runtime-ubuntu20.04
+FROM nvidia/cuda:11.5.0-cudnn8-runtime-ubuntu20.04
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/11/jdk/ubuntu/build.sh
+++ b/11/jdk/ubuntu/build.sh
@@ -1,7 +1,8 @@
 #/bin/bash
 # first run these commands in your shell
 #az login
-#az account set --subscription 5582a4f8-8f93-4e4e-b64c-5a123af91d3f
-#az acr login --name dmdevacr01
+#az account set --subscription 19827096-9747-4941-a512-691966f8531b
+#az acr login --name crappdev
 # Build Nvidia image with JVM slim
-az acr build --file Dockerfile.hotspot.releases.slim --image datomizer/spark-nvidia-jdk11:{{.Run.ID}} --registry DMDevACR01 --resource-group dm-dev-test-01 .
+cd 11/jdk/ubuntu
+az acr build --file Dockerfile.hotspot.releases.slim --image datomizer/spark-nvidia-jdk11:{{.Run.ID}} --registry crappdev --resource-group rg-cr-dev-01 .


### PR DESCRIPTION
1. Downgrading Cuda tools to 11.0.x for compatibility with TF 2.4.1. 
2. Upgraded to Ubuntu 20.4 and newer version of Java 11 based on  openjdk changes